### PR TITLE
feat(user): 로그인 / 로그아웃 구현 및 기타코드 수정 (#9)

### DIFF
--- a/src/main/java/pokemon/pokedex/HomeController.java
+++ b/src/main/java/pokemon/pokedex/HomeController.java
@@ -1,13 +1,23 @@
 package pokemon.pokedex;
 
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.SessionAttribute;
+import pokemon.pokedex.user.dto.LoginResponseDTO;
 
 @Controller
 public class HomeController {
 
     @GetMapping
-    public String home() {
-        return "home";
+    public String home(
+            @SessionAttribute(value = SessionConst.LOGIN_RESPONSE_DTO, required = false) LoginResponseDTO loginResponseDTO,
+            Model model) {
+        if (loginResponseDTO == null) {
+            return "home";
+        }
+
+        model.addAttribute("user", loginResponseDTO);
+        return "loginHome";
     }
 }

--- a/src/main/java/pokemon/pokedex/SessionConst.java
+++ b/src/main/java/pokemon/pokedex/SessionConst.java
@@ -2,5 +2,5 @@ package pokemon.pokedex;
 
 public class SessionConst {
     public static final String USERNAME = "username";
-    public static final String USER_DTO = "userDto";
+    public static final String LOGIN_RESPONSE_DTO = "loginResponseDTO";
 }

--- a/src/main/java/pokemon/pokedex/TestData.java
+++ b/src/main/java/pokemon/pokedex/TestData.java
@@ -2,6 +2,7 @@ package pokemon.pokedex;
 
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Component;
 import pokemon.pokedex.user.domain.AdminRequestStatus;
 import pokemon.pokedex.user.domain.Role;
@@ -21,6 +22,8 @@ public class TestData {
 
     @PostConstruct
     public void init() {
+        BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
+
         RegisterDTO adminDto = new RegisterDTO();
         adminDto.setUsername("관리자");
         adminDto.setLoginId("admin");
@@ -29,6 +32,7 @@ public class TestData {
         adminDto.setConfirmPassword("test");
 
         User admin = User.createByRegisterDto(adminDto);
+        admin.setPassword(encoder.encode(admin.getPassword()));
         admin.setRole(Role.ADMIN);
 
         RegisterDTO userDto1 = new RegisterDTO();
@@ -39,6 +43,7 @@ public class TestData {
         userDto1.setConfirmPassword("test");
 
         User user1 = User.createByRegisterDto(userDto1);
+        user1.setPassword(encoder.encode(user1.getPassword()));
 
         RegisterDTO userDto2 = new RegisterDTO();
         userDto2.setUsername("유저2");
@@ -48,6 +53,7 @@ public class TestData {
         userDto2.setConfirmPassword("test");
 
         User user2 = User.createByRegisterDto(userDto2);
+        user2.setPassword(encoder.encode(user2.getPassword()));
         user2.setAdminRequestStatus(AdminRequestStatus.REQUESTED);
 
         userRepository.save(admin);

--- a/src/main/java/pokemon/pokedex/user/controller/LoginController.java
+++ b/src/main/java/pokemon/pokedex/user/controller/LoginController.java
@@ -1,0 +1,63 @@
+package pokemon.pokedex.user.controller;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import pokemon.pokedex.SessionConst;
+import pokemon.pokedex.user.dto.LoginDTO;
+import pokemon.pokedex.user.dto.LoginResponseDTO;
+import pokemon.pokedex.user.exception.LoginFailedException;
+import pokemon.pokedex.user.service.LoginService;
+
+@Controller
+@RequiredArgsConstructor
+public class LoginController {
+
+    private final LoginService loginService;
+
+    @GetMapping("/login")
+    public String loginForm(@ModelAttribute("user") LoginDTO loginDTO) {
+        return "loginForm";
+    }
+
+    @PostMapping("/login")
+    public String login(
+            @ModelAttribute("user") @Valid LoginDTO loginDTO,
+            BindingResult bindingResult,
+            HttpServletRequest request) {
+
+        LoginResponseDTO loginResponseDTO = null;
+        try {
+            loginResponseDTO = loginService.checkLogin(loginDTO);
+        } catch (LoginFailedException e) {
+            bindingResult.reject("loginFailed", e.getMessage());
+        }
+
+        if (bindingResult.hasErrors()) {
+            return "loginForm";
+        }
+
+        HttpSession session = request.getSession();
+        session.setAttribute(SessionConst.LOGIN_RESPONSE_DTO, loginResponseDTO);
+        session.setMaxInactiveInterval(1800);
+
+        return "redirect:/";
+    }
+
+    @PostMapping("/logout")
+    public String logout(HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+
+        if (session != null) {
+            session.invalidate();
+        }
+        return "redirect:/";
+    }
+
+}

--- a/src/main/java/pokemon/pokedex/user/dto/LoginDTO.java
+++ b/src/main/java/pokemon/pokedex/user/dto/LoginDTO.java
@@ -1,0 +1,16 @@
+package pokemon.pokedex.user.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class LoginDTO {
+
+    @NotEmpty
+    private String loginId;
+
+    @NotEmpty
+    private String password;
+}

--- a/src/main/java/pokemon/pokedex/user/dto/LoginResponseDTO.java
+++ b/src/main/java/pokemon/pokedex/user/dto/LoginResponseDTO.java
@@ -1,0 +1,33 @@
+package pokemon.pokedex.user.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import pokemon.pokedex.user.domain.AdminRequestStatus;
+import pokemon.pokedex.user.domain.Role;
+import pokemon.pokedex.user.domain.User;
+
+@Getter
+@Setter
+public class LoginResponseDTO {
+
+    private Long id;
+    private String loginId;
+    private String username;
+    private Role role;
+    private AdminRequestStatus adminRequestStatus;
+
+    public LoginResponseDTO() {
+    }
+
+    private LoginResponseDTO(User user) {
+        this.id = user.getId();
+        this.loginId = user.getLoginId();
+        this.username = user.getUsername();
+        this.role = user.getRole();
+        this.adminRequestStatus = user.getAdminRequestStatus();
+    }
+
+    public static LoginResponseDTO createByUser(User user) {
+        return new LoginResponseDTO(user);
+    }
+}

--- a/src/main/java/pokemon/pokedex/user/exception/LoginFailedException.java
+++ b/src/main/java/pokemon/pokedex/user/exception/LoginFailedException.java
@@ -1,0 +1,7 @@
+package pokemon.pokedex.user.exception;
+
+public class LoginFailedException extends RuntimeException {
+    public LoginFailedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/pokemon/pokedex/user/service/LoginService.java
+++ b/src/main/java/pokemon/pokedex/user/service/LoginService.java
@@ -1,0 +1,9 @@
+package pokemon.pokedex.user.service;
+
+import pokemon.pokedex.user.dto.LoginDTO;
+import pokemon.pokedex.user.dto.LoginResponseDTO;
+
+public interface LoginService {
+
+    LoginResponseDTO checkLogin(LoginDTO loginDTO);
+}

--- a/src/main/java/pokemon/pokedex/user/service/LoginServiceImpl.java
+++ b/src/main/java/pokemon/pokedex/user/service/LoginServiceImpl.java
@@ -1,0 +1,30 @@
+package pokemon.pokedex.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import pokemon.pokedex.user.dto.LoginDTO;
+import pokemon.pokedex.user.dto.LoginResponseDTO;
+import pokemon.pokedex.user.exception.LoginFailedException;
+import pokemon.pokedex.user.repository.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+public class LoginServiceImpl implements LoginService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public LoginResponseDTO checkLogin(LoginDTO loginDTO) {
+        return userRepository.findByLoginId(loginDTO.getLoginId())
+                .filter(u -> checkPassword(loginDTO.getPassword(), u.getPassword()))
+                .map(LoginResponseDTO::createByUser)
+                .orElseThrow(() -> new LoginFailedException("Please check your loginId or password"));
+    }
+
+    private boolean checkPassword(String rawPassword, String encodedPassword) {
+        PasswordEncoder encoder = new BCryptPasswordEncoder();
+        return encoder.matches(rawPassword, encodedPassword);
+    }
+}

--- a/src/main/resources/templates/loginForm.html
+++ b/src/main/resources/templates/loginForm.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{layout/headLayout :: header(~{::title}, ~{::link})}">
+
+    <title>로그인 - Pokédex</title>
+
+    <!-- 커스텀 CSS -->
+    <link rel="stylesheet" th:href="@{/assets/css/base.css}">
+</head>
+<body>
+<!-- 중앙의 검은 줄 -->
+<div class="center-line"></div>
+
+<div class="container">
+    <div class="contents-container">
+        <h2 class="text-center mb-4">
+            <a class="text-decoration-none text-dark fw-bold" th:href="@{/}">Pokédex</a>
+        </h2>
+        <form id="loginForm" method="post" th:action th:object="${user}">
+            <div class="mb-3">
+                <input class="form-control" id="username" name="username" placeholder="아이디" required="required"
+                       th:field="*{loginId}" type="text">
+                <div class="invalid-feedback">아이디를 입력해주세요.</div>
+            </div>
+
+            <div class="mb-3">
+                <input class="form-control" id="password" name="password" placeholder="비밀번호" required="required"
+                       th:field="*{password}" type="password">
+                <div class="invalid-feedback">비밀번호를 입력해주세요.</div>
+            </div>
+            <div th:if="${#fields.hasGlobalErrors()}">
+                <p class="field-error mt-1 small" th:each="err : ${#fields.globalDetailedErrors()}"
+                   th:if="${err.code == 'loginFailed'}"
+                   th:text="${err.getMessage()}"></p>
+            </div>
+
+            <div>
+                <button class="btn btn-contents w-100 mt-1" type="submit">로그인
+                </button>
+            </div>
+        </form>
+
+        <!-- 추가 링크들 -->
+        <div class="text-center mt-3 login-links">
+            <a href="#">아이디 찾기</a> |
+            <a href="#">비밀번호 찾기</a> |
+            <a th:href="@{/register}">회원가입</a>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/loginHome.html
+++ b/src/main/resources/templates/loginHome.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{layout/headLayout :: header(~{::title}, ~{::link})}">
+
+    <title>Pokédex</title>
+
+    <!-- 커스텀 CSS -->
+    <link rel="stylesheet" th:href="@{/assets/css/base.css}">
+</head>
+<body>
+<!-- 중앙의 검은 줄 -->
+<div class="center-line"></div>
+
+<div class="container">
+    <div class="contents-container">
+        <h2 class="text-center mb-4">
+            <a class="text-decoration-none text-dark fw-bold">Pokédex</a>
+        </h2>
+        <h3 class="text-center mb-4" th:text="${user.username}"></h3>
+        <form method="post" th:action="@{/logout}">
+            <button class="btn btn-contents w-100" type="submit">로그아웃</button>
+        </form>
+    </div>
+</div>
+
+</body>
+</html>

--- a/src/test/java/pokemon/pokedex/HomeControllerTest.java
+++ b/src/test/java/pokemon/pokedex/HomeControllerTest.java
@@ -1,14 +1,15 @@
 package pokemon.pokedex;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import pokemon.pokedex.user.dto.LoginResponseDTO;
 
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -18,9 +19,24 @@ class HomeControllerTest {
     private MockMvc mockMvc;
 
     @Test
+    @DisplayName("일반 홈")
     void home() throws Exception {
         mockMvc.perform(MockMvcRequestBuilders.get("/"))
                 .andExpect(status().isOk())
                 .andExpect(view().name("home"));
     }
+
+    @Test
+    @DisplayName("로그인 홈")
+    void loginHome() throws Exception {
+        LoginResponseDTO loginResponseDTO = new LoginResponseDTO();
+        loginResponseDTO.setUsername("testUsername");
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/")
+                        .sessionAttr(SessionConst.LOGIN_RESPONSE_DTO, loginResponseDTO))
+                .andExpect(status().isOk())
+                .andExpect(view().name("loginHome"))
+                .andExpect(model().attribute("user", loginResponseDTO));
+    }
+
 }

--- a/src/test/java/pokemon/pokedex/HomeControllerUnitTest.java
+++ b/src/test/java/pokemon/pokedex/HomeControllerUnitTest.java
@@ -1,13 +1,14 @@
 package pokemon.pokedex;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import pokemon.pokedex.user.dto.LoginResponseDTO;
 
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(HomeController.class)
 class HomeControllerUnitTest {
@@ -16,9 +17,23 @@ class HomeControllerUnitTest {
     private MockMvc mockMvc;
 
     @Test
+    @DisplayName("일반 홈")
     void home() throws Exception {
         mockMvc.perform(MockMvcRequestBuilders.get("/"))
                 .andExpect(status().isOk())
                 .andExpect(view().name("home"));
+    }
+
+    @Test
+    @DisplayName("로그인 홈")
+    void loginHome() throws Exception {
+        LoginResponseDTO loginResponseDTO = new LoginResponseDTO();
+        loginResponseDTO.setUsername("testUsername");
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/")
+                        .sessionAttr(SessionConst.LOGIN_RESPONSE_DTO, loginResponseDTO))
+                .andExpect(status().isOk())
+                .andExpect(view().name("loginHome"))
+                .andExpect(model().attribute("user", loginResponseDTO));
     }
 }

--- a/src/test/java/pokemon/pokedex/user/controller/LoginControllerTest.java
+++ b/src/test/java/pokemon/pokedex/user/controller/LoginControllerTest.java
@@ -1,0 +1,141 @@
+package pokemon.pokedex.user.controller;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import pokemon.pokedex.SessionConst;
+import pokemon.pokedex.user.domain.User;
+import pokemon.pokedex.user.dto.LoginDTO;
+import pokemon.pokedex.user.dto.LoginResponseDTO;
+import pokemon.pokedex.user.repository.MemoryUserRepository;
+import pokemon.pokedex.user.repository.UserRepository;
+import pokemon.pokedex.user.service.LoginService;
+
+import java.util.stream.Stream;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class LoginControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private LoginService loginService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private LoginDTO loginDTO;
+
+    private static Stream<Arguments> provideErrorInputs() {
+        return Stream.of(
+                Arguments.of("loginId", null, "NotEmpty"),
+                Arguments.of("loginId", "", "NotEmpty"),
+                Arguments.of("password", null, "NotEmpty")
+        );
+    }
+
+    @BeforeEach
+    void setUp() {
+        if (userRepository instanceof MemoryUserRepository) {
+            ((MemoryUserRepository) userRepository).clear();
+        }
+        loginDTO = new LoginDTO();
+        loginDTO.setLoginId("testLoginId");
+        loginDTO.setPassword("testPassword123");
+    }
+
+    @Test
+    @DisplayName("GET 로그인 폼")
+    void loginForm() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/login"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("loginForm"))
+                .andExpect(model().attributeExists("user"));
+    }
+
+    @Test
+    @DisplayName("POST 로그인 성공")
+    void loginSuccess() throws Exception {
+        User user = new User();
+        user.setLoginId(loginDTO.getLoginId());
+        BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
+        user.setPassword(encoder.encode(loginDTO.getPassword()));
+
+        userRepository.save(user);
+
+        LoginResponseDTO expectedLoginResponseDTO = loginService.checkLogin(loginDTO);
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/login")
+                        .flashAttr("user", loginDTO))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/"))
+                .andExpect(request().sessionAttribute(SessionConst.LOGIN_RESPONSE_DTO,
+                        Matchers.samePropertyValuesAs(expectedLoginResponseDTO)));
+    }
+
+    @Test
+    @DisplayName("로그인 실패 예외처리")
+    void loginFail_exception() throws Exception {
+        User user = new User();
+        user.setLoginId(loginDTO.getLoginId());
+        BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
+        user.setPassword(encoder.encode("anotherPassword123"));
+        userRepository.save(user);
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/login")
+                        .flashAttr("user", loginDTO))
+                .andExpect(status().isOk())
+                .andExpect(view().name("loginForm"))
+                .andExpect(model().attributeHasErrors("user"));
+
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideErrorInputs")
+    @DisplayName("로그인 실패 에러코드")
+    void loginFail_error(String field, String value, String errorCode) throws Exception {
+        switch (field) {
+            case "loginId" -> loginDTO.setLoginId(value);
+            case "password" -> loginDTO.setPassword(value);
+        }
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/login")
+                        .flashAttr("user", loginDTO))
+                .andExpect(status().isOk())
+                .andExpect(view().name("loginForm"))
+                .andExpect(model().attributeHasFieldErrorCode("user", field, errorCode));
+    }
+
+    @Test
+    @DisplayName("로그아웃 성공")
+    void logoutSuccess() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.post("/logout"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/"));
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/logout")
+                        .sessionAttr(SessionConst.LOGIN_RESPONSE_DTO, "something"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/"));
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/logout")
+                        .sessionAttr(SessionConst.USERNAME, "something"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/"));
+    }
+
+}

--- a/src/test/java/pokemon/pokedex/user/controller/LoginControllerUnitTest.java
+++ b/src/test/java/pokemon/pokedex/user/controller/LoginControllerUnitTest.java
@@ -1,0 +1,132 @@
+package pokemon.pokedex.user.controller;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import pokemon.pokedex.SessionConst;
+import pokemon.pokedex.user.dto.LoginDTO;
+import pokemon.pokedex.user.dto.LoginResponseDTO;
+import pokemon.pokedex.user.exception.LoginFailedException;
+import pokemon.pokedex.user.service.LoginService;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(LoginController.class)
+class LoginControllerUnitTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private LoginService loginService;
+
+    private LoginDTO loginDTO;
+
+    private static Stream<Arguments> provideFieldErrorInputs() {
+        return Stream.of(
+                Arguments.of("loginId", null, "NotEmpty"),
+                Arguments.of("loginId", "", "NotEmpty"),
+                Arguments.of("password", null, "NotEmpty")
+        );
+    }
+
+    @BeforeEach
+    void setUp() {
+        loginDTO = new LoginDTO();
+        loginDTO.setLoginId("testLoginId");
+        loginDTO.setPassword("testPassword");
+    }
+
+    @Test
+    @DisplayName("GET 로그인 폼")
+    void loginForm() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/login"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("loginForm"))
+                .andExpect(model().attributeExists("user"));
+    }
+
+    @Test
+    @DisplayName("POST 로그인 성공")
+    void loginSuccess() throws Exception {
+        LoginResponseDTO loginResponseDTO = new LoginResponseDTO();
+        loginResponseDTO.setLoginId(loginDTO.getLoginId());
+
+        doReturn(loginResponseDTO).when(loginService).checkLogin(any(LoginDTO.class));
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/login")
+                        .flashAttr("user", loginDTO))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/"))
+                .andExpect(request().sessionAttribute(SessionConst.LOGIN_RESPONSE_DTO, loginResponseDTO));
+
+        ArgumentCaptor<LoginDTO> captor = ArgumentCaptor.forClass(LoginDTO.class);
+        verify(loginService).checkLogin(captor.capture());
+
+        LoginDTO usedloginDTO = captor.getValue();
+        assertThat(usedloginDTO).isEqualTo(loginDTO);
+    }
+
+    @Test
+    @DisplayName("POST 로그인 실패 - 예외")
+    void loginFailed_exception() throws Exception {
+        doThrow(new LoginFailedException("login failed")).when(loginService).checkLogin(any(LoginDTO.class));
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/login")
+                        .flashAttr("user", loginDTO))
+                .andExpect(status().isOk())
+                .andExpect(view().name("loginForm"))
+                .andExpect(model().attributeHasErrors("user"));
+    }
+
+
+    @ParameterizedTest
+    @MethodSource("provideFieldErrorInputs")
+    @DisplayName("POST 로그인 실패 - 필드에러")
+    void loginFailed_error(String field, String value, String errorCode) throws Exception {
+
+        switch (field) {
+            case "loginId" -> loginDTO.setLoginId(value);
+            case "password" -> loginDTO.setPassword(value);
+        }
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/login")
+                        .flashAttr("user", loginDTO))
+                .andExpect(status().isOk())
+                .andExpect(view().name("loginForm"))
+                .andExpect(model().attributeHasFieldErrorCode("user", field, errorCode));
+    }
+
+    @Test
+    @DisplayName("로그아웃 성공")
+    void logoutSuccess() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.post("/logout"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/"));
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/logout")
+                        .sessionAttr(SessionConst.LOGIN_RESPONSE_DTO, "something"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/"));
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/logout")
+                        .sessionAttr(SessionConst.USERNAME, "something"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/"));
+    }
+
+}

--- a/src/test/java/pokemon/pokedex/user/controller/RegisterControllerTest.java
+++ b/src/test/java/pokemon/pokedex/user/controller/RegisterControllerTest.java
@@ -160,7 +160,7 @@ public class RegisterControllerTest {
                 .andExpect(redirectedUrl("/"));
 
         mockMvc.perform(MockMvcRequestBuilders.get("/register/success")
-                        .sessionAttr(SessionConst.USER_DTO, "something"))
+                        .sessionAttr(SessionConst.LOGIN_RESPONSE_DTO, "something"))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrl("/"));
     }

--- a/src/test/java/pokemon/pokedex/user/controller/RegisterControllerUnitTest.java
+++ b/src/test/java/pokemon/pokedex/user/controller/RegisterControllerUnitTest.java
@@ -184,7 +184,7 @@ class RegisterControllerUnitTest {
                 .andExpect(redirectedUrl("/"));
 
         mockMvc.perform(MockMvcRequestBuilders.get("/register/success")
-                        .sessionAttr(SessionConst.USER_DTO, "something"))
+                        .sessionAttr(SessionConst.LOGIN_RESPONSE_DTO, "something"))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrl("/"));
     }

--- a/src/test/java/pokemon/pokedex/user/service/LoginServiceImplTest.java
+++ b/src/test/java/pokemon/pokedex/user/service/LoginServiceImplTest.java
@@ -1,0 +1,75 @@
+package pokemon.pokedex.user.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import pokemon.pokedex.user.domain.User;
+import pokemon.pokedex.user.dto.LoginDTO;
+import pokemon.pokedex.user.dto.LoginResponseDTO;
+import pokemon.pokedex.user.exception.LoginFailedException;
+import pokemon.pokedex.user.repository.UserRepository;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class LoginServiceImplTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private LoginServiceImpl loginServiceImpl;
+
+    @Test
+    @DisplayName("로그인 성공")
+    void checkLogin_success() {
+        LoginDTO loginDTO = new LoginDTO();
+        loginDTO.setLoginId("testLoginId");
+        loginDTO.setPassword("testPassword");
+
+        User user = new User();
+        user.setLoginId(loginDTO.getLoginId());
+        BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+        String encodedPassword = passwordEncoder.encode(loginDTO.getPassword());
+        user.setPassword(encodedPassword);
+        doReturn(Optional.of(user)).when(userRepository).findByLoginId(any(String.class));
+
+        LoginResponseDTO loginResponseDTO = loginServiceImpl.checkLogin(loginDTO);
+
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(userRepository, times(1)).findByLoginId(captor.capture());
+        String usedLoginId = captor.getValue();
+        assertThat(usedLoginId).isEqualTo(loginDTO.getLoginId());
+        assertThat(loginResponseDTO.getLoginId()).isEqualTo(user.getLoginId());
+    }
+
+    @Test
+    @DisplayName("로그인 실패 예외")
+    void checkLogin_fail_exception() {
+        LoginDTO loginDTO = new LoginDTO();
+        loginDTO.setLoginId("testLoginId");
+        loginDTO.setPassword("testPassword");
+
+        User user = new User();
+        user.setLoginId(loginDTO.getLoginId());
+        BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+        String encodedPassword = passwordEncoder.encode("anotherPassword");
+        user.setPassword(encodedPassword);
+        doReturn(Optional.of(user)).when(userRepository).findByLoginId(any(String.class));
+
+        assertThatThrownBy(() -> loginServiceImpl.checkLogin(loginDTO))
+                .isInstanceOf(LoginFailedException.class);
+
+    }
+
+}

--- a/src/test/java/pokemon/pokedex/user/service/LoginServiceTest.java
+++ b/src/test/java/pokemon/pokedex/user/service/LoginServiceTest.java
@@ -1,0 +1,65 @@
+package pokemon.pokedex.user.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import pokemon.pokedex.user.domain.User;
+import pokemon.pokedex.user.dto.LoginDTO;
+import pokemon.pokedex.user.dto.LoginResponseDTO;
+import pokemon.pokedex.user.exception.LoginFailedException;
+import pokemon.pokedex.user.repository.MemoryUserRepository;
+import pokemon.pokedex.user.repository.UserRepository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+class LoginServiceTest {
+
+    @Autowired
+    private LoginService loginService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private LoginDTO loginDTO;
+
+    @BeforeEach
+    void setUp() {
+        if (userRepository instanceof MemoryUserRepository) {
+            ((MemoryUserRepository) userRepository).clear();
+        }
+        loginDTO = new LoginDTO();
+        loginDTO.setLoginId("testLoginId");
+        loginDTO.setPassword("testPassword");
+    }
+
+    @Test
+    @DisplayName("로그인 성공")
+    void checkLogin_success() {
+        BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
+        User user = new User();
+        user.setLoginId(loginDTO.getLoginId());
+        user.setPassword(encoder.encode(loginDTO.getPassword()));
+        userRepository.save(user);
+
+        LoginResponseDTO loginResponseDTO = loginService.checkLogin(loginDTO);
+        assertThat(loginResponseDTO.getLoginId()).isEqualTo(loginDTO.getLoginId());
+    }
+
+    @Test
+    @DisplayName("로그인 실패 예외처리")
+    void checkLogin_fail_exception() {
+        BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
+        User user = new User();
+        user.setLoginId(loginDTO.getLoginId());
+        user.setPassword(encoder.encode("anotherPassword"));
+        userRepository.save(user);
+
+        assertThatThrownBy(() -> loginService.checkLogin(loginDTO))
+                .isInstanceOf(LoginFailedException.class);
+    }
+}

--- a/src/test/java/pokemon/pokedex/user/service/RegisterServiceImplTest.java
+++ b/src/test/java/pokemon/pokedex/user/service/RegisterServiceImplTest.java
@@ -53,21 +53,6 @@ class RegisterServiceImplTest {
     }
 
     @Test
-    @DisplayName("중복 아이디 아니면 정상작동")
-    void validateDuplicatedLoginId_normal() {
-        String loginId = UUID.randomUUID().toString();
-        doReturn(false).when(userRepository).existsByLoginId(any(String.class));
-
-        registerServiceImpl.validateDuplicatedLoginId(loginId);
-
-        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
-        verify(userRepository).existsByLoginId(captor.capture());
-
-        String usedLoginId = captor.getValue();
-        assertThat(usedLoginId).isEqualTo(loginId);
-    }
-
-    @Test
     @DisplayName("같은 비밀번호를 입력해도 다른 값이 나오는지 확인")
     void encodedPassword() {
         RegisterDTO registerDTO = new RegisterDTO();
@@ -92,6 +77,21 @@ class RegisterServiceImplTest {
         log.info("registerDTO password: {}", registerDTO.getPassword());
         log.info("user1 password: {}", usedUser1.getPassword());
         log.info("user2 password: {}", usedUser2.getPassword());
+    }
+
+    @Test
+    @DisplayName("중복 아이디 아니면 정상작동")
+    void validateDuplicatedLoginId_normal() {
+        String loginId = UUID.randomUUID().toString();
+        doReturn(false).when(userRepository).existsByLoginId(any(String.class));
+
+        registerServiceImpl.validateDuplicatedLoginId(loginId);
+
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(userRepository).existsByLoginId(captor.capture());
+
+        String usedLoginId = captor.getValue();
+        assertThat(usedLoginId).isEqualTo(loginId);
     }
 
     @Test


### PR DESCRIPTION
<!--- 제목 : feat: 추기한 기능 (#이슈번호) -->

## 🪾 반영 브랜치
- `feature/login` -> `develop`

<!--- ex) `feature/login` -> `develop` -->

## #️⃣ Issue Number
Closes #9 
<!--- ex) Fixes #이슈번호 / Closes #이슈번호 / Resolves #이슈번호 / Relates to #이슈번호 -->

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
### 로그인 / 로그아웃 기능 구현

- (추가) LoginController
  - loginForm: 로그인 폼 화면 띄우는 컨트롤러
  - login: 로그인 폼 제출하는 컨트롤러
  - logout: 로그아웃 하는 컨트롤러
 
- (추가) LoginDTO: 로그인 폼으로 부터 받아오는 데이터
- (추가) LoginResponseDTO: 로그인 성공 시 서버에서 클라이언트로 보내는 데이터
- (추가) LoginFailedException: 로그인 실패시 LoginService에서 내보내는 예외
- (추가) LoginService: 로그인 관련 서비스 인터페이스
  - checkLogin: 로그인 확인을 하는 메서드
- (추가) LoginServiceImpl: 
  - checkPassword: checkLogin에서 암호화 된 password와 loginDTO의 패스워드 체크를 하기위한 메서드
- (추가) loginForm: 로그인 제출용 폼
- (추가) loginHome: 로그인 전용 홈
- (추가) LoginController, LoginService 단위 / 통합 테스트

- (수정) HomeController - home: 세션 값 기준으로 로그인 홈 / 일반 홈 분리
- (수정) RegisterServiceImplTest 메소드 위치 변경 - 메소드 위치 짝이 안맞아서
- (수정) SessionConst의 USER_DTO -> LOGIN_RESPONSE_DTO로 수정하면서 USER_DTO가 쓰였던 부분 전부 수정함. (RegisterControllerTest, RegisterControllerUnitTest) - 나중에 UserDTO라는 DTO를 만들면 헷갈릴 우려가 있어보여서
- (수정) TestData에 그냥 평문으로 password를 store에 저장해서 로그인 체크할 때 BCrypt로 암호화한 password랑 비교할 때 실패가 되어서 TestData에 비밀번호 넣는 부분을 수정함.


## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 테스트 추가, 테스트 리팩토링

## 📸 스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
