### PR TITLE
Fix: 로그인 한 유저가 로그인 / 회원가입 폼에 접근 가능한 문제 해결

### DIFF
--- a/src/main/java/pokemon/pokedex/user/UserConfig.java
+++ b/src/main/java/pokemon/pokedex/user/UserConfig.java
@@ -1,0 +1,16 @@
+package pokemon.pokedex.user;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import pokemon.pokedex.user.interceptor.GuestOnlyInterceptor;
+
+@Configuration
+public class UserConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new GuestOnlyInterceptor())
+                .addPathPatterns("/login", "/register");
+    }
+}

--- a/src/main/java/pokemon/pokedex/user/interceptor/GuestOnlyInterceptor.java
+++ b/src/main/java/pokemon/pokedex/user/interceptor/GuestOnlyInterceptor.java
@@ -1,0 +1,21 @@
+package pokemon.pokedex.user.interceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import org.springframework.web.servlet.HandlerInterceptor;
+import pokemon.pokedex.SessionConst;
+
+public class GuestOnlyInterceptor implements HandlerInterceptor {
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        HttpSession session = request.getSession(false);
+
+        if (session != null && session.getAttribute(SessionConst.LOGIN_RESPONSE_DTO) != null) {
+            response.sendRedirect(request.getContextPath() + "/");
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/test/java/pokemon/pokedex/user/interceptor/GuestOnlyInterceptorTest.java
+++ b/src/test/java/pokemon/pokedex/user/interceptor/GuestOnlyInterceptorTest.java
@@ -1,0 +1,53 @@
+package pokemon.pokedex.user.interceptor;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import pokemon.pokedex.SessionConst;
+import pokemon.pokedex.user.dto.LoginResponseDTO;
+
+import java.util.stream.Stream;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class GuestOnlyInterceptorTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    private static Stream<Arguments> provideArguments() {
+        return Stream.of(
+                Arguments.of("/login", "loginForm"),
+                Arguments.of("/register", "registerForm")
+
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideArguments")
+    @DisplayName("게스트 접근")
+    void guest(String url, String expectedFormName) throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get(url))
+                .andExpect(status().isOk())
+                .andExpect(view().name(expectedFormName));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"/login", "/register"})
+    @DisplayName("로그인 유저 접근")
+    void loginUser(String url) throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get(url)
+                        .sessionAttr(SessionConst.LOGIN_RESPONSE_DTO, new LoginResponseDTO()))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/"));
+    }
+}

--- a/src/test/java/pokemon/pokedex/user/interceptor/GuestOnlyInterceptorTest.java
+++ b/src/test/java/pokemon/pokedex/user/interceptor/GuestOnlyInterceptorTest.java
@@ -44,8 +44,13 @@ public class GuestOnlyInterceptorTest {
     @ParameterizedTest
     @ValueSource(strings = {"/login", "/register"})
     @DisplayName("로그인 유저 접근")
-    void loginUser(String url) throws Exception {
+    void loginUser_get(String url) throws Exception {
         mockMvc.perform(MockMvcRequestBuilders.get(url)
+                        .sessionAttr(SessionConst.LOGIN_RESPONSE_DTO, new LoginResponseDTO()))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/"));
+
+        mockMvc.perform(MockMvcRequestBuilders.post(url)
                         .sessionAttr(SessionConst.LOGIN_RESPONSE_DTO, new LoginResponseDTO()))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrl("/"));

--- a/src/test/java/pokemon/pokedex/user/interceptor/GuestOnlyInterceptorUnitTest.java
+++ b/src/test/java/pokemon/pokedex/user/interceptor/GuestOnlyInterceptorUnitTest.java
@@ -57,6 +57,11 @@ class GuestOnlyInterceptorUnitTest {
                         .sessionAttr(SessionConst.LOGIN_RESPONSE_DTO, new LoginResponseDTO()))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrl("/"));
+
+        mockMvc.perform(MockMvcRequestBuilders.post(url)
+                        .sessionAttr(SessionConst.LOGIN_RESPONSE_DTO, new LoginResponseDTO()))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/"));
     }
 
 }

--- a/src/test/java/pokemon/pokedex/user/interceptor/GuestOnlyInterceptorUnitTest.java
+++ b/src/test/java/pokemon/pokedex/user/interceptor/GuestOnlyInterceptorUnitTest.java
@@ -1,0 +1,62 @@
+package pokemon.pokedex.user.interceptor;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import pokemon.pokedex.SessionConst;
+import pokemon.pokedex.user.controller.LoginController;
+import pokemon.pokedex.user.controller.RegisterController;
+import pokemon.pokedex.user.dto.LoginResponseDTO;
+import pokemon.pokedex.user.service.LoginService;
+import pokemon.pokedex.user.service.RegisterService;
+
+import java.util.stream.Stream;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest({LoginController.class, RegisterController.class})
+class GuestOnlyInterceptorUnitTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private LoginService loginService;
+
+    @MockitoBean
+    private RegisterService registerService;
+
+    private static Stream<Arguments> provideArguments() {
+        return Stream.of(
+                Arguments.of("/login", "loginForm"),
+                Arguments.of("/register", "registerForm")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideArguments")
+    @DisplayName("게스트 접근")
+    void guest(String url, String form) throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get(url))
+                .andExpect(status().isOk())
+                .andExpect(view().name(form));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"/login", "/register"})
+    @DisplayName("유저 접근")
+    void loginUser(String url) throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get(url)
+                        .sessionAttr(SessionConst.LOGIN_RESPONSE_DTO, new LoginResponseDTO()))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/"));
+    }
+
+}


### PR DESCRIPTION
<!--- 제목 : feat: 추기한 기능 (#이슈번호) -->

## 🪾 반영 브랜치

<!--- ex) `feature/login` -> `develop` -->
`fix/redirect-logged-in-users` -> `develop`

## #️⃣ Issue Number

<!--- ex) Fixes #이슈번호 / Closes #이슈번호 / Resolves #이슈번호 / Relates to #이슈번호 -->
Fixes #11

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

- GuestOnlyInterceptor를 만들어서 컨트롤러에 도달하기 전에 세션으로 로그인 된 유저인지 아닌지 체크한 후, 로그인 된 유저라면 홈화면으로 redirect 하고 아니라면 그대로 진행하도록 수정했다. - 흐름이 자연스럽지 않아서 수정함.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 버그 수정
- [x] 테스트 추가, 테스트 리팩토링

## 📸 스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
