### PR TITLE
feat: userService의 requestAdminRole 인자 수정 및 관련 메서드 수정 (#39)

### DIFF
--- a/src/main/java/pokemon/pokedex/admin/AdminController.java
+++ b/src/main/java/pokemon/pokedex/admin/AdminController.java
@@ -52,7 +52,7 @@ public class AdminController {
         SessionUserDTO sessionUserDTO = (SessionUserDTO) request.getAttribute(SessionConst.SESSION_USER_DTO);
 
         log.debug("Request admin role, userId: {}, loginId: {}", sessionUserDTO.getId(), sessionUserDTO.getLoginId());
-        userService.requestAdminRole(sessionUserDTO.getId());
+        userService.requestAdminRole(sessionUserDTO);
 
         return "redirect:/admin/alert";
     }

--- a/src/main/java/pokemon/pokedex/user/repository/UserRepository.java
+++ b/src/main/java/pokemon/pokedex/user/repository/UserRepository.java
@@ -21,5 +21,5 @@ public interface UserRepository {
 
     int updateAdminRequestStatusById(Long id, AdminRequestStatus status);
 
-    public void deleteById(Long id);
+    void deleteById(Long id);
 }

--- a/src/main/java/pokemon/pokedex/user/service/UserService.java
+++ b/src/main/java/pokemon/pokedex/user/service/UserService.java
@@ -6,5 +6,5 @@ public interface UserService {
 
     SessionUserDTO getRealUserDTO(SessionUserDTO sessionUserDTO);
 
-    void requestAdminRole(Long userId);
+    void requestAdminRole(SessionUserDTO sessionUserDTO);
 }

--- a/src/main/java/pokemon/pokedex/user/service/UserServiceImpl.java
+++ b/src/main/java/pokemon/pokedex/user/service/UserServiceImpl.java
@@ -27,9 +27,13 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public void requestAdminRole(Long userId) {
-        int updateCnt = userRepository.updateAdminRequestStatusById(userId, AdminRequestStatus.REQUESTED);
-
+    public void requestAdminRole(SessionUserDTO sessionUserDTO) {
+        long userId = sessionUserDTO.getId();
+        AdminRequestStatus adminRequestStatus = sessionUserDTO.getAdminRequestStatus();
+        int updateCnt = 0;
+        if (adminRequestStatus == AdminRequestStatus.NONE || adminRequestStatus == AdminRequestStatus.REJECTED)
+            updateCnt = userRepository.updateAdminRequestStatusById(userId, AdminRequestStatus.REQUESTED);
+        
         if (updateCnt == 0) {
             log.debug("Nothing updated in DB, userId = {}", userId);
             return;

--- a/src/test/java/pokemon/pokedex/admin/AdminControllerUnitTest.java
+++ b/src/test/java/pokemon/pokedex/admin/AdminControllerUnitTest.java
@@ -61,13 +61,13 @@ class AdminControllerUnitTest {
     @Test
     void requestAdminRole() throws Exception {
         SessionUserDTO sessionUserDTO = new SessionUserDTO();
-        sessionUserDTO.setId(123L);
+        sessionUserDTO.setId(-1L);
 
         mockMvc.perform(MockMvcRequestBuilders.post("/admin/alert")
                         .requestAttr(SessionConst.SESSION_USER_DTO, sessionUserDTO))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrl("/admin/alert"));
 
-        verify(userService).requestAdminRole(sessionUserDTO.getId());
+        verify(userService).requestAdminRole(sessionUserDTO);
     }
 }

--- a/src/test/java/pokemon/pokedex/user/service/UserServiceTest.java
+++ b/src/test/java/pokemon/pokedex/user/service/UserServiceTest.java
@@ -78,7 +78,7 @@ class UserServiceTest {
         SessionUserDTO sessionUserDTO = loginService.checkLogin(createLoginDTO(alreadySessionInfos));
         Long userId = sessionUserDTO.getId();
 
-        userService.requestAdminRole(userId);
+        userService.requestAdminRole(sessionUserDTO);
 
         assertThat(userRepository.findById(userId).get().getAdminRequestStatus()).isEqualTo(expectedAdminRequestStatus);
         SessionUserDTO findSessionUserDTO = (SessionUserDTO) sessionRegistry.getSessionsByUserId(userId).get(0)
@@ -99,7 +99,7 @@ class UserServiceTest {
 
         sessionRegistry.addSession(userId, session);
 
-        userService.requestAdminRole(userId);
+        userService.requestAdminRole(sessionUserDTO);
 
         assertThat(userRepository.findById(userId).get().getAdminRequestStatus()).isEqualTo(adminRequestStatus);
         SessionUserDTO findSessionUserDTO = (SessionUserDTO) sessionRegistry.getSessionsByUserId(userId).get(0)
@@ -111,10 +111,12 @@ class UserServiceTest {
     @DisplayName("requestAdminRole_유저 없으면 아무 변화 없음")
     void requestAdminRole_nothing_not_error() {
 
-        assertThat(sessionRegistry.getSessionsByUserId(123L)).isEmpty();
 
-        userService.requestAdminRole(123L);
+        assertThat(sessionRegistry.getSessionsByUserId(-1L)).isEmpty();
+        SessionUserDTO sessionUserDTO = new SessionUserDTO();
+        sessionUserDTO.setId(-1L);
+        userService.requestAdminRole(sessionUserDTO);
 
-        assertThat(sessionRegistry.getSessionsByUserId(123L)).isEmpty();
+        assertThat(sessionRegistry.getSessionsByUserId(-1L)).isEmpty();
     }
 }


### PR DESCRIPTION
<!--- 제목 : feat: 추기한 기능 (#이슈번호) -->

## 🪾 반영 브랜치

`feature/user-requestAdminRole` -> `develop`

## #️⃣ Issue Number

<!--- ex) Fixes #이슈번호 / Closes #이슈번호 / Resolves #이슈번호 / Relates to #이슈번호 -->
Closes #39 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 인자를 userId를 넘기는 것에서, sessionUserDTO 자체를 넘기도록 함.
- 서비스에서 sessionUserDTO 의 AdminRequestStatus를 보고 업데이트 할 것인지 아닌지 판단하는게 맞다고 생각해서 수정함.
- AdminRequestStatus가 NONE, REJECTED 상태일 때만 업데이트 하게끔 변경함.

+ UserService 인터페이스에 public으로 선언된 메서드가 있어서 public 제거해줌.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 코드 리팩토링

## 📸 스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
